### PR TITLE
  feat: Add pagination support to prevent token limit issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+### Added
+- `DEFAULT_MAX_MARKDOWN_LENGTH` configuration setting (default: 20000 characters) to prevent response token limit issues
+- `content_info` field in `read_documentation` responses showing pagination metadata when content is truncated
+- Automatic application of default max length when `max_length` parameter is not explicitly provided
+
+### Changed
+- `read_documentation` now defaults to returning max 20,000 characters to avoid exceeding LLM token limits (e.g., Claude's 25,000 token limit)
+- Enhanced docstring for `read_documentation` tool with detailed parameter and return value documentation
+
 ## [0.3.0] - 2025-10-06
 ### Fixed
 - Windows compatibility: Use `posixpath.normpath()` for URL path normalization instead of `os.path.normpath()`

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Create a `.env` file in the repo root. The helper script writes sensible default
 | `SERVER_PORT` | `8000` | TCP port for streamable HTTP transport. |
 | `MCP_LOG_LEVEL` | `WARNING` | Logging verbosity (DEBUG/INFO/WARNING/ERROR). |
 | `MD_CACHE_SIZE` | `512` | In-memory CachedDoc LRU capacity (counts pages). |
+| `DEFAULT_MAX_MARKDOWN_LENGTH` | `20000` | Default maximum characters returned per request (prevents token limit issues). |
 
 ## Dev Setup and Run
 ```
@@ -139,10 +140,18 @@ Example MCP request/response for `read_documentation` (trimmed for brevity):
     "links": [
       {"text": "QStringList", "url": "https://doc.qt.io/archives/qt-4.8/qstringlist.html"}
     ],
-    "attribution": "Content © The Qt Company Ltd./Digia — GNU Free Documentation License 1.3"
+    "attribution": "Content © The Qt Company Ltd./Digia — GNU Free Documentation License 1.3",
+    "content_info": {
+      "total_length": 15234,
+      "returned_length": 2000,
+      "start_index": 0,
+      "truncated": true
+    }
   }
 }
 ```
+
+**Note**: The `content_info` field appears when content is paginated or truncated. Use `start_index` and `max_length` parameters to retrieve additional pages. By default, responses are limited to 20,000 characters to avoid exceeding LLM token limits.
 
 ## Deployment
 - **Direct (systemd, bare metal, CI runners):**

--- a/src/qt4_doc_mcp_server/config.py
+++ b/src/qt4_doc_mcp_server/config.py
@@ -25,6 +25,7 @@ class Settings:
     preconvert_md: bool = True
     md_cache_size: int = 512
     mcp_log_level: str = "WARNING"
+    default_max_markdown_length: int = 20000
 
 
 def load_settings() -> Settings:
@@ -53,6 +54,7 @@ def load_settings() -> Settings:
     s.preconvert_md = os.getenv("PRECONVERT_MD", str(s.preconvert_md)).lower() == "true"
     s.md_cache_size = int(os.getenv("MD_CACHE_SIZE", str(s.md_cache_size)))
     s.mcp_log_level = os.getenv("MCP_LOG_LEVEL", s.mcp_log_level)
+    s.default_max_markdown_length = int(os.getenv("DEFAULT_MAX_MARKDOWN_LENGTH", str(s.default_max_markdown_length)))
     return s
 
 

--- a/tests/test_doc_service.py
+++ b/tests/test_doc_service.py
@@ -110,3 +110,127 @@ def test_read_documentation_returns_section_only(sample_settings: Settings) -> N
     assert len(result_section["markdown"]) < len(result_full["markdown"])  # smaller slice
     assert result_section["links"]
     assert any("#anchor" in link["url"] for link in result_section["links"])
+
+
+def test_read_documentation_applies_default_max_length(tmp_path: Path) -> None:
+    """Test that default_max_markdown_length is applied when max_length is not provided."""
+    # Create a longer HTML document
+    long_content = "\n".join([f"<p>Paragraph {i} with some content.</p>" for i in range(100)])
+    html = f"""
+    <html>
+      <head><title>Long Document</title></head>
+      <body>
+        <div class="mainContent">
+          <h1>Long Document</h1>
+          {long_content}
+        </div>
+      </body>
+    </html>
+    """
+    (tmp_path / "qlong.html").write_text(html, encoding="utf-8")
+    
+    settings = Settings(
+        qt_doc_base=tmp_path,
+        md_cache_dir=tmp_path / "cache" / "md",
+        index_db_path=tmp_path / "index" / "fts.sqlite",
+        preindex_docs=False,
+        preconvert_md=False,
+        md_cache_size=4,
+        default_max_markdown_length=500,  # Short limit for testing
+    )
+    ensure_dirs(settings)
+    configure_from_settings(settings)
+    
+    url = "https://doc.qt.io/archives/qt-4.8/qlong.html"
+    result = asyncio.run(read_documentation(url))
+    
+    # Should be truncated to 500 characters
+    assert len(result["markdown"]) == 500
+    assert "content_info" in result
+    assert result["content_info"]["truncated"] is True
+    assert result["content_info"]["returned_length"] == 500
+    assert result["content_info"]["total_length"] > 500
+
+
+def test_read_documentation_explicit_max_length_overrides_default(tmp_path: Path) -> None:
+    """Test that explicit max_length parameter overrides default setting."""
+    long_content = "\n".join([f"<p>Paragraph {i}.</p>" for i in range(100)])
+    html = f"""
+    <html>
+      <head><title>Long Document</title></head>
+      <body>
+        <div class="mainContent">
+          <h1>Long Document</h1>
+          {long_content}
+        </div>
+      </body>
+    </html>
+    """
+    (tmp_path / "qlong2.html").write_text(html, encoding="utf-8")
+    
+    settings = Settings(
+        qt_doc_base=tmp_path,
+        md_cache_dir=tmp_path / "cache" / "md",
+        index_db_path=tmp_path / "index" / "fts.sqlite",
+        preindex_docs=False,
+        preconvert_md=False,
+        md_cache_size=4,
+        default_max_markdown_length=500,
+    )
+    ensure_dirs(settings)
+    configure_from_settings(settings)
+    
+    url = "https://doc.qt.io/archives/qt-4.8/qlong2.html"
+    # Explicitly request 300 characters
+    result = asyncio.run(read_documentation(url, max_length=300))
+    
+    # Should use explicit value, not default
+    assert len(result["markdown"]) == 300
+    assert "content_info" in result
+    assert result["content_info"]["returned_length"] == 300
+
+
+def test_read_documentation_pagination_with_start_index(tmp_path: Path) -> None:
+    """Test pagination using start_index and max_length."""
+    html = """
+    <html>
+      <head><title>Paginated Doc</title></head>
+      <body>
+        <div class="mainContent">
+          <h1>Paginated Doc</h1>
+          <p>First paragraph.</p>
+          <p>Second paragraph.</p>
+          <p>Third paragraph.</p>
+        </div>
+      </body>
+    </html>
+    """
+    (tmp_path / "qpage.html").write_text(html, encoding="utf-8")
+    
+    settings = Settings(
+        qt_doc_base=tmp_path,
+        md_cache_dir=tmp_path / "cache" / "md",
+        index_db_path=tmp_path / "index" / "fts.sqlite",
+        preindex_docs=False,
+        preconvert_md=False,
+        md_cache_size=4,
+        default_max_markdown_length=20000,
+    )
+    ensure_dirs(settings)
+    configure_from_settings(settings)
+    
+    url = "https://doc.qt.io/archives/qt-4.8/qpage.html"
+    
+    # Get first page
+    page1 = asyncio.run(read_documentation(url, start_index=0, max_length=50))
+    assert len(page1["markdown"]) == 50
+    assert page1["content_info"]["start_index"] == 0
+    
+    # Get second page
+    page2 = asyncio.run(read_documentation(url, start_index=50, max_length=50))
+    assert len(page2["markdown"]) == 50
+    assert page2["content_info"]["start_index"] == 50
+    
+    # Pages should have different content
+    assert page1["markdown"] != page2["markdown"]
+


### PR DESCRIPTION
  - Add DEFAULT_MAX_MARKDOWN_LENGTH config (20k chars) to avoid exceeding LLM token limits
  - Auto-apply default max length when max_length param not provided
  - Include content_info metadata in responses when content is truncated
  - Add comprehensive tests for pagination and default length behavior

  This commit message follows conventional commit format and summarizes the key changes: the new configuration setting, automatic application of defaults, the content_info field for pagination metadata, and the test
  coverage.